### PR TITLE
fix: Correct path in service_provider

### DIFF
--- a/service_provider.go
+++ b/service_provider.go
@@ -27,7 +27,7 @@ func (receiver *ServiceProvider) Boot(app foundation.Application) {
 	// You can also publish this config file manually, uncomment the following code and run ./artisan vendor:publish --package=github.com/goravel/example-package
 
 	// app.Publishes("github.com/goravel/example-package", map[string]string{
-	// 	"config/hello.go": app.ConfigPath("hello.go"),
+	// 	"setup/config/hello.go": app.ConfigPath("hello.go"),
 	// })
 
 	app.Commands([]console.Command{


### PR DESCRIPTION
## 📑 Description

Correct the path to point to _setup/config/hello.go_ for the configuration file that should be published when `artisan vendor:publish` is called.
